### PR TITLE
Handle socket errors raised by getpeername

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -27,5 +27,5 @@ setup(name="tornwamp",
       packages=find_packages(),
       tests_require=["coverage==4.0.3", "nose==1.3.7", "pep8==1.7.0", "mock==1.0.1", "pylint==1.5.4"],
       url = "http://github.com/ef-ctx/tornwamp",
-      version="1.1.0"
+      version="1.1.1"
 )

--- a/tests/test_session.py
+++ b/tests/test_session.py
@@ -1,11 +1,29 @@
+import socket
 import unittest
 from datetime import datetime
 
-from mock import patch
+from mock import patch, MagicMock
 from tornwamp.session import ClientConnection, ConnectionDict
 
 
 class ClientConnectionTestCase(unittest.TestCase):
+
+    def test_peer_on_not_connected_socket(self):
+        ws = MagicMock()
+        ws.ws_connection.stream.socket = socket.socket()
+        ws.request.remote_ip = "127.0.0.1"
+        client = ClientConnection(ws)
+        client.id = 42
+        self.assertEqual(client.peer, "127.0.0.1:HACK|42")
+
+    def test_peer_on_closed_socket(self):
+        ws = MagicMock()
+        ws.ws_connection.stream.socket = socket.socket()
+        ws.ws_connection.stream.socket.close()
+        ws.request.remote_ip = "127.0.0.1"
+        client = ClientConnection(ws)
+        client.id = 42
+        self.assertEqual(client.peer, "127.0.0.1:HACK|42")
 
     @patch("tornwamp.session.datetime")
     @patch("tornwamp.session.create_global_id", return_value=1111)


### PR DESCRIPTION
When the socket is not connected or loses a connection peer property would raise an exception. I propose it does the same thing it currently does for AttributeError.